### PR TITLE
DOO-26813: slim image SBOM workflow outputs

### DIFF
--- a/.github/workflows/generate-image-sbom.yml
+++ b/.github/workflows/generate-image-sbom.yml
@@ -164,7 +164,7 @@ jobs:
           mv "${SBOM_FILE}.tmp" "$SBOM_FILE"
 
       - name: Upload SPDX-JSON SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ needs.resolve-image.outputs.spdx-json-artifact-name }}
           path: ${{ needs.resolve-image.outputs.spdx-json-output-file }}
@@ -206,7 +206,7 @@ jobs:
           mv "${SBOM_FILE}.tmp" "$SBOM_FILE"
 
       - name: Upload CycloneDX-JSON SBOM
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ needs.resolve-image.outputs.cyclonedx-json-artifact-name }}
           path: ${{ needs.resolve-image.outputs.cyclonedx-json-output-file }}


### PR DESCRIPTION
JIRA task: DOO-26813

Changes:
- disable Syft file catalogers with select-catalogers: ["-file"]
- pin anchore/sbom-action to v0.24.0
- keep Node 24 artifact upload action