### PR TITLE
DOO-26813: disable SPDX file ownership entries

### DIFF
--- a/.github/workflows/generate-image-sbom.yml
+++ b/.github/workflows/generate-image-sbom.yml
@@ -149,6 +149,8 @@ jobs:
           cat > syft-config.yaml <<'YAML'
           select-catalogers:
             - "-file"
+          relationships:
+            package-file-ownership: false
           YAML
 
       - name: Generate SPDX-JSON SBOM
@@ -200,6 +202,8 @@ jobs:
           cat > syft-config.yaml <<'YAML'
           select-catalogers:
             - "-file"
+          relationships:
+            package-file-ownership: false
           YAML
 
       - name: Generate CycloneDX-JSON SBOM


### PR DESCRIPTION
JIRA task: DOO-26813

Changes:
- keep Syft file catalogers disabled with select-catalogers: ["-file"]
- disable Syft package-to-file ownership relationships so SPDX output no longer contains the full file inventory
- keep package-file-ownership-overlap unchanged to avoid changing package counts