### PR TITLE
DOO-26813: exclude OS packages from SBOMs

### DIFF
--- a/.github/workflows/generate-image-sbom.yml
+++ b/.github/workflows/generate-image-sbom.yml
@@ -149,6 +149,7 @@ jobs:
           cat > syft-config.yaml <<'YAML'
           select-catalogers:
             - "-file"
+            - "-os"
           relationships:
             package-file-ownership: false
           YAML
@@ -202,6 +203,7 @@ jobs:
           cat > syft-config.yaml <<'YAML'
           select-catalogers:
             - "-file"
+            - "-os"
           relationships:
             package-file-ownership: false
           YAML


### PR DESCRIPTION
JIRA task: DOO-26813

Changes:
- exclude OS package catalogers with select-catalogers: ["-os"]
- keep file catalogers disabled with select-catalogers: ["-file"]
- keep package-to-file ownership relationships disabled for slim SPDX output